### PR TITLE
Specify default style IDs in view constructors.

### DIFF
--- a/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectExpandableListView.java
+++ b/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectExpandableListView.java
@@ -26,7 +26,7 @@ public class EdgeEffectExpandableListView extends android.widget.ExpandableListV
   }
 
 	public EdgeEffectExpandableListView(Context context, AttributeSet attrs) {
-		this(context, attrs, 0);
+		this(context, attrs, android.R.attr.expandableListViewStyle);
 	}
 
 	public EdgeEffectExpandableListView(Context context, AttributeSet attrs, int defStyle) {

--- a/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectGridView.java
+++ b/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectGridView.java
@@ -26,7 +26,7 @@ public class EdgeEffectGridView extends android.widget.GridView {
   }
 
 	public EdgeEffectGridView(Context context, AttributeSet attrs) {
-		this(context, attrs, 0);
+		this(context, attrs, android.R.attr.gridViewStyle);
 	}
 
 	public EdgeEffectGridView(Context context, AttributeSet attrs, int defStyle) {

--- a/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectListView.java
+++ b/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectListView.java
@@ -27,7 +27,7 @@ public class EdgeEffectListView extends android.widget.ListView {
   }
 
   public EdgeEffectListView(Context context, AttributeSet attrs) {
-    this(context, attrs, 0);
+    this(context, attrs, android.R.attr.listViewStyle);
   }
 
   public EdgeEffectListView(Context context, AttributeSet attrs, int defStyle) {

--- a/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectScrollView.java
+++ b/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectScrollView.java
@@ -26,7 +26,7 @@ public class EdgeEffectScrollView extends android.widget.ScrollView {
   }
 
 	public EdgeEffectScrollView(Context context, AttributeSet attrs) {
-		this(context, attrs, 0);
+		this(context, attrs, android.R.attr.scrollViewStyle);
 	}
 
 	public EdgeEffectScrollView(Context context, AttributeSet attrs, int defStyle) {

--- a/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectWebView.java
+++ b/Library/src/uk/co/androidalliance/edgeeffectoverride/EdgeEffectWebView.java
@@ -27,7 +27,7 @@ public class EdgeEffectWebView extends android.webkit.WebView {
 	}
 
 	public EdgeEffectWebView(Context context, AttributeSet attrs) {
-		this(context, attrs, 0);
+		this(context, attrs, android.R.attr.webViewStyle);
 	}
 
   public EdgeEffectWebView(Context context, AttributeSet attrs, int defStyle) {


### PR DESCRIPTION
This allows the views to use the application defined theme without having to manually specify a style on each one.
