### PR TITLE
Set minSdk to 10. Seems to work fine in the emulator.

### DIFF
--- a/Library/AndroidManifest.xml
+++ b/Library/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="11"
+        android:minSdkVersion="10"
         android:targetSdkVersion="17" />
 
 </manifest>


### PR DESCRIPTION
SDK 10 is still at [33%](http://developer.android.com/about/dashboards/index.html) as of August, 2013. No reason not to support it as long as it works.

I didn't test very thoroughly, just a single ListView in an emulator running 2.3.3 
